### PR TITLE
Convert resource attributes to a hash with indifferent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,10 @@ Changelog
 Unreleased
 ----------
 
-Convert resource attributes to a hash with indifferent access, so that you can
-use symbol or string keys.
+No changes.
+
+0.2.0
+-----
+
+- Convert resource attributes to a hash with indifferent access,
+  so that you can use symbol or string keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+Unreleased
+----------
+
+Convert resource attributes to a hash with indifferent access, so that you can
+use symbol or string keys.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passfort (0.1.0)
+    passfort (0.2.0)
       activesupport (~> 5.0)
       excon (~> 0.60)
 
@@ -26,7 +26,7 @@ GEM
       rubocop (~> 0.52.1)
       rubocop-rspec (~> 1.22.0)
     hashdiff (0.3.7)
-    i18n (0.9.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.11.3)

--- a/lib/passfort/resource/base.rb
+++ b/lib/passfort/resource/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/hash"
+
 module Passfort
   module Resource
     class Base
@@ -8,7 +10,7 @@ module Passfort
       end
 
       def initialize(attributes)
-        @attributes = attributes.symbolize_keys
+        @attributes = attributes.with_indifferent_access
       end
 
       def to_h

--- a/lib/passfort/resource/profile.rb
+++ b/lib/passfort/resource/profile.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash"
 require "passfort/resource/task"
 
 module Passfort

--- a/lib/passfort/version.rb
+++ b/lib/passfort/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passfort
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/integration/company_ownership_check_spec.rb
+++ b/spec/integration/company_ownership_check_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe "running a company ownership check" do
 
     check = client.checks.create(profile_id: profile.id, check_type: "COMPANY_OWNERSHIP")
 
-    shareholders = check.output_data["ownership_structure"]["shareholders"]
-    beneficial_owners = shareholders.select { |sh| sh["total_percentage"] >= 25 }
+    shareholders = check.output_data[:ownership_structure][:shareholders]
+    beneficial_owners = shareholders.select { |sh| sh[:total_percentage] >= 25 }
 
     collected_data = client.profiles.collected_data(profile.id).to_h
 
-    collected_data["ownership_structure"] ||= {}
-    collected_data["ownership_structure"]["shareholders"] = beneficial_owners
+    collected_data[:ownership_structure] ||= {}
+    collected_data[:ownership_structure][:shareholders] = beneficial_owners
 
     client.profiles.update_collected_data(profile.id, collected_data)
   end


### PR DESCRIPTION
This lets us access resource attributes using symbol keys _or_ string keys. I would prefer to only use symbols, but that would be more of a breaking change, so I figure this is an easier option.