### PR TITLE
Include specific errors in API errors

### DIFF
--- a/lib/passfort/errors.rb
+++ b/lib/passfort/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "passfort/errors/api_error"
+require "passfort/errors/unknown_api_error"
 require "passfort/errors/chargeable_limit_reached_error"
 require "passfort/errors/invalid_api_key_error"
 require "passfort/errors/invalid_input_data_error"

--- a/lib/passfort/errors/api_error.rb
+++ b/lib/passfort/errors/api_error.rb
@@ -4,11 +4,12 @@ module Passfort
   module Errors
     # Represents any response from the API which is not a 200 OK
     class APIError < StandardError
-      attr_reader :response
+      attr_reader :response, :errors
 
-      def initialize(msg, response = nil)
+      def initialize(msg, errors = [], response = nil)
         super(msg)
         @response = response
+        @errors = errors
       end
     end
   end

--- a/lib/passfort/errors/chargeable_limit_reached_error.rb
+++ b/lib/passfort/errors/chargeable_limit_reached_error.rb
@@ -4,8 +4,8 @@ module Passfort
   module Errors
     # Specific error class for when the chargeable limit has been reached
     class ChargeableLimitReachedError < APIError
-      def initialize(response = nil)
-        super("Rate limit exceeded", response)
+      def initialize(*args)
+        super("Rate limit exceeded", *args)
       end
     end
   end

--- a/lib/passfort/errors/invalid_api_key_error.rb
+++ b/lib/passfort/errors/invalid_api_key_error.rb
@@ -4,8 +4,8 @@ module Passfort
   module Errors
     # Specific error class for when an invalid API key is used to access the service
     class InvalidAPIKeyError < APIError
-      def initialize(response = nil)
-        super("Invalid API key", response)
+      def initialize(*args)
+        super("Invalid API key", *args)
       end
     end
   end

--- a/lib/passfort/errors/invalid_input_data_error.rb
+++ b/lib/passfort/errors/invalid_input_data_error.rb
@@ -4,8 +4,8 @@ module Passfort
   module Errors
     # Specific error class for when an invalid input data is used to query the service
     class InvalidInputDataError < APIError
-      def initialize(response = nil)
-        super("Invalid input data", response)
+      def initialize(*args)
+        super("Invalid input data", *args)
       end
     end
   end

--- a/lib/passfort/errors/request_error.rb
+++ b/lib/passfort/errors/request_error.rb
@@ -4,8 +4,8 @@ module Passfort
   module Errors
     # Specific error class for when an HTTP request error has occurred
     class RequestError < APIError
-      def initialize(response)
-        super("Request API error - HTTP #{response.status}", response)
+      def initialize(errors, response)
+        super("Request API error - HTTP #{response.status}", errors, response)
       end
     end
   end

--- a/lib/passfort/errors/unknown_api_error.rb
+++ b/lib/passfort/errors/unknown_api_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Passfort
+  module Errors
+    # Specific error class for when an unknown error is returned
+    class UnknownApiError < APIError
+      def initialize(*args)
+        super("Unknown API error", *args)
+      end
+    end
+  end
+end

--- a/lib/passfort/http.rb
+++ b/lib/passfort/http.rb
@@ -36,25 +36,22 @@ module Passfort
     # error codes: https://passfort.com/developer/v4/data-reference/ErrorCodes
     def handle_error(response, body)
       unless [200, 201].include?(response.status)
-        raise Passfort::Errors::RequestError, response
+        raise Passfort::Errors::RequestError.new([], response)
       end
 
       errors = body["errors"].is_a?(Array) ? body["errors"] : [body["errors"]]
 
-      handle_response_error(errors[0], response) if errors.any?
+      handle_response_error(errors, response) if errors.any?
     end
 
-    def handle_response_error(error, response)
-      case error["code"]
-      when 201
-        raise Passfort::Errors::InvalidInputDataError, response
-      when 204
-        raise Passfort::Errors::InvalidAPIKeyError, response
-      when 104
-        raise Passfort::Errors::ChargeableLimitReachedError, response
-      else
-        raise Passfort::Errors::APIError.new("Unknown API error", response)
-      end
+    def handle_response_error(errors, response)
+      error_class = case errors[0]["code"]
+                    when 201 then Passfort::Errors::InvalidInputDataError
+                    when 204 then Passfort::Errors::InvalidAPIKeyError
+                    when 104 then Passfort::Errors::ChargeableLimitReachedError
+                    else Passfort::Errors::UnknownApiError
+                    end
+      raise error_class.new(errors, response)
     end
   end
 end

--- a/spec/passfort/http_spec.rb
+++ b/spec/passfort/http_spec.rb
@@ -18,45 +18,35 @@ RSpec.describe Passfort::Http do
       let(:status) { 404 }
       let(:error_class) { Passfort::Errors::RequestError }
 
-      it "raises a specific APIError" do
-        is_expected.to raise_error(instance_of(error_class))
-      end
+      it { is_expected.to raise_error(error_class) }
     end
 
     context "when returning an invalid API Key error" do
       let(:error_code) { 204 }
       let(:error_class) { Passfort::Errors::InvalidAPIKeyError }
 
-      it "raises a specific APIError" do
-        is_expected.to raise_error(instance_of(error_class))
-      end
+      it { is_expected.to raise_error(error_class) }
     end
 
     context "when returning an invalid input data error" do
       let(:error_code) { 201 }
       let(:error_class) { Passfort::Errors::InvalidInputDataError }
 
-      it "raises a specific APIError" do
-        is_expected.to raise_error(instance_of(error_class))
-      end
+      it { is_expected.to raise_error(error_class) }
     end
 
     context "when returning a chargeable limit reached error" do
       let(:error_code) { 104 }
       let(:error_class) { Passfort::Errors::ChargeableLimitReachedError }
 
-      it "raises a specific APIError" do
-        is_expected.to raise_error(instance_of(error_class))
-      end
+      it { is_expected.to raise_error(error_class) }
     end
 
     context "when returning an unknown API error" do
       let(:error_code) { 203 }
-      let(:error_class) { Passfort::Errors::APIError }
+      let(:error_class) { Passfort::Errors::UnknownApiError }
 
-      it "raises a specific APIError" do
-        is_expected.to raise_error(instance_of(error_class))
-      end
+      it { is_expected.to raise_error(error_class) }
     end
 
     context "when returning a successful result" do


### PR DESCRIPTION
Also create an UnknownApiError class for, you know, unknown API errors.