### PR TITLE
Raise UnparseableResponseError when response cannot be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+No changes.
+
+0.2.2
+----------
+
 - Raise UnparsesableResponseError when the response cannot be parsed as JSON.
 
 0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-No changes.
+- Raise UnparsesableResponseError when the response cannot be parsed as JSON.
 
 0.2.1
 -----

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passfort (0.2.1)
+    passfort (0.2.2)
       activesupport (~> 5.0)
       excon (~> 0.60)
 

--- a/lib/passfort/errors.rb
+++ b/lib/passfort/errors.rb
@@ -6,6 +6,7 @@ require "passfort/errors/chargeable_limit_reached_error"
 require "passfort/errors/invalid_api_key_error"
 require "passfort/errors/invalid_input_data_error"
 require "passfort/errors/request_error"
+require "passfort/errors/unparseable_response_error"
 
 module Passfort
   module Errors

--- a/lib/passfort/errors/unparseable_response_error.rb
+++ b/lib/passfort/errors/unparseable_response_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Passfort
+  module Errors
+    class UnparseableResponseError < APIError
+      def initialize(*args)
+        super("Unparseable response body", *args)
+      end
+    end
+  end
+end

--- a/lib/passfort/http.rb
+++ b/lib/passfort/http.rb
@@ -18,6 +18,8 @@ module Passfort
       body = JSON.parse(response.body)
       handle_error(response, body)
       body
+    rescue JSON::ParserError
+      raise Passfort::Errors::UnparseableResponseError.new([], response)
     end
 
     def post(path, body:)
@@ -29,6 +31,8 @@ module Passfort
       body = JSON.parse(response.body)
       handle_error(response, body)
       body
+    rescue JSON::ParserError
+      raise Passfort::Errors::UnparseableResponseError.new([], response)
     end
 
     private

--- a/lib/passfort/version.rb
+++ b/lib/passfort/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passfort
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/passfort/http_spec.rb
+++ b/spec/passfort/http_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Passfort::Http do
       it { is_expected.to raise_error(error_class) }
     end
 
+    context "when returning a response that can't be parsed as JSON" do
+      let(:body) { "<html><body><h1>something that isn't json</h1></body></html>" }
+      let(:error_class) { Passfort::Errors::UnparseableResponseError }
+
+      it { is_expected.to raise_error(error_class) }
+    end
+
     context "when returning a successful result" do
       let(:result) { subject.call }
 


### PR DESCRIPTION
Instead of JSON::ParserError, raise UnparseableResponseError (a subclass
of Passfort::APIError) when the body of a response cannot be parsed as
JSON.