### PR TITLE
Add ActiveSupport::Notifications support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Unreleased
 
 No changes.
 
+0.3.0
+-----
+
+- Add `ActiveSupport::Notifications` support.
+
 0.2.3
 -----
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
@@ -83,6 +84,7 @@ DEPENDENCIES
   pry (~> 0.10)
   rspec (~> 3.2)
   rspec_junit_formatter (~> 0.3)
+  timecop (~> 0.8)
   webmock (~> 3.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passfort (0.2.3)
+    passfort (0.3.0)
       activesupport (~> 5.0)
       excon (~> 0.60)
 

--- a/lib/passfort/version.rb
+++ b/lib/passfort/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passfort
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/passfort.gemspec
+++ b/passfort.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.3"
+  spec.add_development_dependency "timecop", "~> 0.8"
   spec.add_development_dependency "webmock", "~> 3.3"
 end


### PR DESCRIPTION
Provide instrumentation hooks for requests.
Include Timecop gem to provide time travel and time freezing for tests.