### PR TITLE
Allow setting timeout parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Unreleased
 
 No changes.
 
+0.3.1
+-----
+
+- Allow setting connection properties
+
 0.3.0
 -----
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passfort (0.3.0)
+    passfort (0.3.1)
       activesupport (~> 5.0)
       excon (~> 0.60)
 

--- a/lib/passfort/client.rb
+++ b/lib/passfort/client.rb
@@ -4,8 +4,8 @@ require "passfort/http"
 
 module Passfort
   class Client
-    def initialize(api_key:)
-      @http = Passfort::Http.new(api_key)
+    def initialize(api_key:, excon_opts: {})
+      @http = Passfort::Http.new(api_key, excon_opts)
     end
 
     def profiles

--- a/lib/passfort/http.rb
+++ b/lib/passfort/http.rb
@@ -9,9 +9,12 @@ module Passfort
     DOMAIN = "https://api.passfort.com"
     ROOT_PATH = "/4.0"
 
-    def initialize(api_key, connection: Excon.new(DOMAIN))
+    attr_reader :api_key, :connection
+
+    def initialize(api_key, excon_opts = {})
       @api_key = api_key
-      @connection = connection
+      uri = excon_opts[:domain] || DOMAIN
+      @connection = Excon.new(uri, excon_opts.except(:domain))
     end
 
     def get(path)

--- a/lib/passfort/version.rb
+++ b/lib/passfort/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passfort
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/passfort/http_spec.rb
+++ b/spec/passfort/http_spec.rb
@@ -110,6 +110,34 @@ RSpec.describe Passfort::Http do
     end
   end
 
+  describe "#initialize" do
+    describe "with an API key" do
+      it "sets the .api_key" do
+        expect(http.api_key).to eq("api_key")
+      end
+
+      it "sets a default endpoint" do
+        expect(described_class::DOMAIN).to include(http.connection.data[:hostname])
+      end
+    end
+
+    it "accepts an alternate endpoint" do
+      example_endpoint = "https://example.net"
+      client = described_class.new("api_key", "domain": example_endpoint)
+      expect(example_endpoint).to include(client.connection.data[:hostname])
+    end
+
+    it "supports setting open_timeout" do
+      http = described_class.new("api_key", "open_timeout": 1)
+      expect(http.connection.data[:open_timeout]).to eq(1)
+    end
+
+    it "supports setting read_timeout" do
+      http = described_class.new("api_key", "read_timeout": 2)
+      expect(http.connection.data[:read_timeout]).to eq(2)
+    end
+  end
+
   describe "#get" do
     subject { -> { http.get(path) } }
 


### PR DESCRIPTION
Client now accepts a configuration that will be passed to the Excon
client, allowing setting different components, such as timeouts or debug
flags.
Bump version to 0.3.1