### PR TITLE
Add search company functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Unreleased
 
 No changes.
 
+0.4.0
+-----
+
+- Add `company_search` functionality
+
 0.3.1
 -----
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passfort (0.3.1)
+    passfort (0.4.0)
       activesupport (~> 5.0)
       excon (~> 0.60)
 

--- a/lib/passfort/client.rb
+++ b/lib/passfort/client.rb
@@ -19,5 +19,17 @@ module Passfort
     def tasks
       Endpoint::Tasks.new(@http)
     end
+
+    def company_search(country, query, state = nil, provider = nil)
+      search_query = "/search/companies?country=#{CGI.escape(country)}"
+      search_query += "&query=#{CGI.escape(query)}"
+      search_query += "&state=#{CGI.escape(state)}" unless state.nil?
+      search_query += "&provider=#{CGI.escape(provider)}" unless provider.nil?
+
+      response = @http.get(search_query)
+      response["companies"].map do |company|
+        Passfort::Resource::CompanySummary.new(company)
+      end
+    end
   end
 end

--- a/lib/passfort/resource.rb
+++ b/lib/passfort/resource.rb
@@ -3,6 +3,7 @@
 require "passfort/resource/base"
 require "passfort/resource/profile"
 require "passfort/resource/company_data"
+require "passfort/resource/company_summary"
 require "passfort/resource/task"
 require "passfort/resource/check"
 

--- a/lib/passfort/resource/company_summary.rb
+++ b/lib/passfort/resource/company_summary.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Passfort
+  module Resource
+    class CompanySummary < Base
+      attributes :name, :number, :country, :state
+    end
+  end
+end

--- a/lib/passfort/version.rb
+++ b/lib/passfort/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passfort
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/fixtures/companies.json
+++ b/spec/fixtures/companies.json
@@ -1,0 +1,19 @@
+{
+    "companies": [
+        {
+            "country": "GBR",
+            "name": "GOCARDLESS LTD",
+            "number": "07495895"
+        },
+        {
+            "country": "GBR",
+            "name": "GO CARD LIMITED",
+            "number": "07269277"
+        },
+        {
+            "country": "GBR",
+            "name": "GO CAR DIRECT LTD",
+            "number": "10333984"
+        }
+    ]
+}

--- a/spec/passfort/client_spec.rb
+++ b/spec/passfort/client_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Passfort::Client do
+  let(:client) { described_class.new(api_key: "api_key") }
+
+  describe "#company_search" do
+    let(:result) { client.company_search(country, query, state, provider) }
+
+    let(:country) { "GBR" }
+    let(:query) { "GoCard" }
+    let(:state) { nil }
+    let(:provider) { "duedil" }
+
+    before do
+      stub_request(
+        :get,
+        %r{/search/companies\?country=#{country}&provider=#{provider}&query=#{query}\z},
+      ).to_return(status: 200, body: load_fixture("companies.json"))
+    end
+
+    it "returns an array of companies" do
+      expect(result).to be_a(Array)
+    end
+
+    it "returns expected number of companies" do
+      expect(result.count).to eq(3)
+    end
+
+    it "returns right type of company summary resource" do
+      expect(result[0]).to be_a(Passfort::Resource::CompanySummary)
+    end
+
+    it "returns maps company summary data" do
+      expect(result[0]).to have_attributes(
+        country: "GBR",
+        name: "GOCARDLESS LTD",
+        number: "07495895",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Passfort has added a new functionality to allow you to search for
companies: https://passfort.com/developer/v4/api-reference/Search.
We include this in the client, with the new `company_search` method.